### PR TITLE
Issues with gemfile and windows environment.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   pry
@@ -33,4 +34,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/artist.rb
+++ b/lib/artist.rb
@@ -1,0 +1,3 @@
+class Artist
+
+end

--- a/lib/genre.rb
+++ b/lib/genre.rb
@@ -1,0 +1,3 @@
+class Genre
+
+end

--- a/lib/song.rb
+++ b/lib/song.rb
@@ -1,0 +1,3 @@
+class Song
+
+end


### PR DESCRIPTION
I've been using atom editor instead of nitrous and never had any issues, until now. Maybe need to research how to use on a Windows machine.

C:/Ruby22-x64/lib/ruby/gems/2.2.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:34:in `block in setup': You have already activated rspec-support 3.4.1, but your Gemfile requires rspec-support 3.3.0. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)